### PR TITLE
リポジトリ検索結果をStar数でソートできる機能を追加

### DIFF
--- a/lib/application/state/repository_notifier.dart
+++ b/lib/application/state/repository_notifier.dart
@@ -4,12 +4,27 @@ import 'package:coding_test_yumemi/application/di/reposiroty_di.dart';
 import 'package:coding_test_yumemi/domain/type/repository.dart';
 
 class RepositoryNotifier extends FamilyAsyncNotifier<List<Repository>, String> {
+  bool isStarAscending = true; // 昇順か降順かを保持するフラグ
+
   @override
   Future<List<Repository>> build(String arg) async {
     final searchResponse =
         await ref.read(searchRepositoryGetUsecaseProvider).execute(arg);
     final repositories = searchResponse.items;
     return repositories;
+  }
+
+  void toggleSortByStarCount() {
+    isStarAscending = !isStarAscending;
+
+    state.whenData((repositories) {
+      final sortedRepositories = List<Repository>.from(repositories)
+        ..sort((a, b) => isStarAscending
+            ? a.stargazersCount.compareTo(b.stargazersCount)
+            : b.stargazersCount.compareTo(a.stargazersCount));
+
+      state = AsyncValue.data(sortedRepositories);
+    });
   }
 }
 

--- a/lib/presentation/widget/repository_search_delegate.dart
+++ b/lib/presentation/widget/repository_search_delegate.dart
@@ -54,7 +54,7 @@ class RepositorySearchResults extends HookConsumerWidget {
     return repositoryState.when(
       data: (repositories) => repositories.isEmpty
           ? _buildEmptyMessage()
-          : _buildRepositoryList(repositories),
+          : _buildRepositoryList(ref, repositories),
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) => ErrorMessageWidget(message: error.toString()),
     );
@@ -69,13 +69,45 @@ class RepositorySearchResults extends HookConsumerWidget {
     );
   }
 
-  Widget _buildRepositoryList(List<Repository> repositories) {
+  Widget _buildRepositoryList(WidgetRef ref, List<Repository> repositories) {
     return SafeArea(
-      child: ListView.builder(
-        itemCount: repositories.length,
-        itemBuilder: (context, index) => SearchResultsItemCard(
-          key: ValueKey(repositories[index].id),
-          repository: repositories[index],
+      child: Column(
+        children: [
+          _buildSortButton(ref),
+          Expanded(
+            child: ListView.builder(
+              itemCount: repositories.length,
+              itemBuilder: (context, index) => SearchResultsItemCard(
+                key: ValueKey(repositories[index].id),
+                repository: repositories[index],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSortButton(WidgetRef ref) {
+    final notifier = ref.read(repositoryNotifierProvider(query).notifier);
+    final isStarAscending = notifier.isStarAscending;
+
+    return Padding(
+      padding: EdgeInsets.all(8.r),
+      child: SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: () {
+            notifier.toggleSortByStarCount();
+          },
+          style: ElevatedButton.styleFrom(
+            foregroundColor: Colors.black,
+            backgroundColor: Colors.blue[100],
+          ),
+          child: Text(
+            isStarAscending ? 'Star数（昇順）' : 'Star数（降順）',
+            style: TextStyle(fontSize: 14.sp),
+          ),
         ),
       ),
     );

--- a/lib/presentation/widget/search_results_item_card.dart
+++ b/lib/presentation/widget/search_results_item_card.dart
@@ -22,6 +22,10 @@ class SearchResultsItemCard extends ConsumerWidget {
               repository.name,
               style: TextStyle(fontSize: 16.sp),
             ),
+            subtitle: Text(
+              'Star: ${repository.stargazersCount.toString()}',
+              style: TextStyle(fontSize: 12.sp),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## 概要
検索して表示されたリポジトリ一覧をStar数でソートできる機能を追加

## 変更内容
- 検索で表示された画面にソートボタンを追加
- ボタンを押すとListViewがStar数でソートされる（ボタンを押すたびに昇順と降順が切り替わる）